### PR TITLE
Add support for sending a string as the caller

### DIFF
--- a/Enklu.Commons.Unity.Logging.Test/LogFormatter_Tests.cs
+++ b/Enklu.Commons.Unity.Logging.Test/LogFormatter_Tests.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Enklu.Commons.Unity.Logging.Test
+{
+    [Parallelizable(ParallelScope.None)]
+    [TestFixture]
+    public class LogFormatter_Tests
+    {
+        private DefaultLogFormatter _formatter;
+        
+        [SetUp]
+        public void Setup()
+        {
+            _formatter = new DefaultLogFormatter();
+            _formatter.Timestamp = false;
+            _formatter.Level = false;
+        }
+        
+        [Test]
+        public void StringCaller()
+        {
+            var log = _formatter.Format(LogLevel.Info, "Custom", "Message");
+            Assert.AreEqual("[Custom]\tMessage\n", log);
+        }
+    }
+}

--- a/Enklu.Commons.Unity.Logging.Test/Log_Tests.cs
+++ b/Enklu.Commons.Unity.Logging.Test/Log_Tests.cs
@@ -73,5 +73,13 @@ namespace Enklu.Commons.Unity.Logging.Test
             
             Assert.AreEqual(string.Format(toReplace, str, num), _target.Message);
         }
+        
+        [Test]
+        public void Json()
+        {
+            var json = "{\"name\":{\"first\":\"thor\"}}";
+            
+            Assert.DoesNotThrow(() => Log.Info(this, json, new object[0]));
+        }
     }
 }

--- a/Enklu.Commons.Unity.Logging/DefaultLogFormatter.cs
+++ b/Enklu.Commons.Unity.Logging/DefaultLogFormatter.cs
@@ -67,7 +67,15 @@ namespace Enklu.Commons.Unity.Logging
 
             if (TypeName && null != caller)
             {
-                log.AppendFormat("[{0}]", caller.GetType().FullName);
+                var callerType = caller.GetType();
+                if (callerType == typeof(string))
+                {
+                    log.AppendFormat("[{0}]", caller);
+                }
+                else
+                {
+                    log.AppendFormat("[{0}]", callerType.FullName);
+                }
             }
 
             if (ObjectToString && null != caller)

--- a/Enklu.Commons.Unity.Logging/Enklu.Commons.Unity.Logging.csproj
+++ b/Enklu.Commons.Unity.Logging/Enklu.Commons.Unity.Logging.csproj
@@ -2,14 +2,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net35</TargetFramework>
-    <AssemblyVersion>2020.8.0</AssemblyVersion>
+    <AssemblyVersion>2020.11.0</AssemblyVersion>
     <Version>0.7.3</Version>
     <Description></Description>
     <Copyright></Copyright>
     <Authors></Authors>
     <IncludeSymbols>True</IncludeSymbols>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <FileVersion>2020.8.0</FileVersion>
+    <FileVersion>2020.11.0</FileVersion>
     <IsPackable>false</IsPackable>
     <PackageId />
     <PackageVersion />


### PR DESCRIPTION
Now, calls like `Log.Info("SomethingInAStaticContext", "Something important happened")` no longer log with `[System.string]` as the caller.

Also added a test. And apparently a test I never pushed awhile ago.